### PR TITLE
collector4

### DIFF
--- a/R/collector.R
+++ b/R/collector.R
@@ -1,0 +1,76 @@
+# initiate global tibble to store the results
+globals <- new.env()
+globals$archive <- tibble(
+  call = list(),
+  env = list()
+)
+
+# Add collect_and_rethrow() before the original body
+# and set the original function as the "unmodified" attribute
+set_collector <- function(fun, force = FALSE) {
+  new_fun <- fun
+  body(new_fun) <- call(
+    "{",
+    quote(collect_and_rethrow()),
+    body(fun)
+  )
+  # note: trace() calls it "original" so we picked a new name
+  attr(new_fun, "unmodified") <- fun
+  new_fun
+}
+
+# * copy caller env and all the chain up to a special env, but every binding is lazy
+# * store the call and env in the global tibble
+# * on.exit, go through the envs and remove every binding that is still lazy, it's
+#   not been used, by reference it will update the global tibble too
+# * use the original function to eval the call, and do it in the new env, return
+#   this value from the original function call
+collect_and_rethrow <- function() {
+  new_caller_env <- env_clone_lazy(parent.frame(2))
+  call = sys.call(-1)
+  archive(
+    call = call,
+    env = new_caller_env
+  )
+  rlang::eval_bare(bquote(on.exit(env_cleanup(.(new_caller_env)))), parent.frame())
+
+  call[[1]] <-  attr(sys.function(-1), "unmodified")
+  rlang::return_from(parent.frame(), eval(call, new_caller_env))
+}
+
+
+
+# note: env_clone doesn't do deep copy, i.e we're not cloning environments that
+# are bound in `e`, or nested in lists, or found in attributes, or as function enclosures
+env_clone_lazy <- function(env) {
+  # we stop the recursion when we find a special env, defined by having a name
+  if (!is.null(attr(env, "name")) || identical(env, emptyenv())) return(env)
+  parent_clone <- env_clone_lazy(env_parent(env))
+  clone <- rlang::env_clone(env, parent = parent_clone)
+  for (nm in names(clone)) {
+    #FIXME: assumes env contains no active or lazy bindings, this could be fixed
+    env_bind_lazy(clone, !!nm := !!env[[nm]])
+  }
+  clone
+}
+
+# drop lazy bindings, since these were not used
+env_cleanup <- function(env) {
+  if (!is.null(attr(env, "name")) || identical(env, emptyenv())) return(env)
+  env_cleanup(env_parent(env))
+  lazy_lgl <- env_binding_are_lazy(env)
+  rm(list = names(lazy_lgl)[lazy_lgl], envir = env)
+}
+
+archive <- function(
+    call,
+    env
+) {
+  globals$archive  <- rbind(
+    globals$archive,
+    tibble(
+      call = list(call),
+      env = list(env)
+    )
+  )
+}

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -153,19 +153,7 @@
 #' mutate(starwars, prod = .data[[vars[[1]]]] * .data[[vars[[2]]]])
 #' # Learn more in ?dplyr_data_masking
 mutate <- function(.data, ...) {
-  ..new_caller_env <- env_clone_lazy(parent.frame())
-  ..call = sys.call()
-  archive(
-    call = ..call,
-    env = ..new_caller_env
-  )
-  on.exit({
-    env_cleanup(..new_caller_env)
-  })
-  ..call[[1]] <- function(.data, ...) {
-    UseMethod("mutate")
-  }
-  eval(..call, ..new_caller_env)
+  UseMethod("mutate")
 }
 
 #' @rdname mutate

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -153,7 +153,19 @@
 #' mutate(starwars, prod = .data[[vars[[1]]]] * .data[[vars[[2]]]])
 #' # Learn more in ?dplyr_data_masking
 mutate <- function(.data, ...) {
-  UseMethod("mutate")
+  ..new_caller_env <- env_clone_lazy(parent.frame())
+  ..call = sys.call()
+  archive(
+    call = ..call,
+    env = ..new_caller_env
+  )
+  on.exit({
+    env_cleanup(..new_caller_env)
+  })
+  ..call[[1]] <- function(.data, ...) {
+    UseMethod("mutate")
+  }
+  eval(..call, ..new_caller_env)
 }
 
 #' @rdname mutate

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -117,20 +117,9 @@
 #' summarise(starwars, avg = mean(.data[[var]], na.rm = TRUE))
 #' # Learn more in ?dplyr_data_masking
 summarise <- function(.data, ..., .groups = NULL) {
-  ..new_caller_env <- env_clone_lazy(parent.frame())
-  ..call = sys.call()
-  archive(
-    call = ..call,
-    env = ..new_caller_env
-  )
-  on.exit({
-    env_cleanup(..new_caller_env)
-  })
-  ..call[[1]] <- function(.data, ...) {
-    UseMethod("summarise")
-  }
-  eval(..call, ..new_caller_env)
+  UseMethod("summarise")
 }
+
 #' @rdname summarise
 #' @export
 summarize <- summarise

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -117,7 +117,19 @@
 #' summarise(starwars, avg = mean(.data[[var]], na.rm = TRUE))
 #' # Learn more in ?dplyr_data_masking
 summarise <- function(.data, ..., .groups = NULL) {
-  UseMethod("summarise")
+  ..new_caller_env <- env_clone_lazy(parent.frame())
+  ..call = sys.call()
+  archive(
+    call = ..call,
+    env = ..new_caller_env
+  )
+  on.exit({
+    env_cleanup(..new_caller_env)
+  })
+  ..call[[1]] <- function(.data, ...) {
+    UseMethod("summarise")
+  }
+  eval(..call, ..new_caller_env)
 }
 #' @rdname summarise
 #' @export

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,4 +1,8 @@
 .onLoad <- function(libname, pkgname) {
+  mutate <<- set_collector(mutate)
+  summarise <<- set_collector(summarise)
+  summarize <<- set_collector(summarize)
+
   op <- options()
   op.dplyr <- list(
     dplyr.show_progress = TRUE


### PR DESCRIPTION
This is a general approach that should work on any closure, S3 Generic or not.
We don't use quosures, just lazy bindings.

I believe it was wrong to start from the execution environment, the caller is where we have all we need, combined with the call itself.

We do a clone of the caller and its parents up to a named env (the global env has no name so it will be cloned too), with the difference that we populate these envs purely with lazy bindings.

On exit we cleanup, and keep only regular bindings, the assumption being that bindings that are still lazy were not used, which I can only imagine being wrong in very artificial cases. 

Semi manual reprex:

```
library(dplyr, w = F)

mutate
#> function (.data, ...) 
#> {
#>     collect_and_rethrow()
#>     {
#>         UseMethod("mutate")
#>     }
#> }
#> <environment: namespace:dplyr>
#> attr(,"unmodified")
#> function(.data, ...) {
#>   UseMethod("mutate")
#> }
#> <bytecode: 0x10adfe398>
#> <environment: namespace:dplyr>

starwars %>%
  select(name, mass) %>%
  mutate(
    mass2 = mass * 2,
    mass2_squared = mass2 * mass2
  )
#> # A tibble: 87 × 4
#>    name                mass mass2 mass2_squared
#>    <chr>              <dbl> <dbl>         <dbl>
#>  1 Luke Skywalker        77   154         23716
#>  2 C-3PO                 75   150         22500
#>  3 R2-D2                 32    64          4096
#>  4 Darth Vader          136   272         73984
#>  5 Leia Organa           49    98          9604
#>  6 Owen Lars            120   240         57600
#>  7 Beru Whitesun lars    75   150         22500
#>  8 R5-D4                 32    64          4096
#>  9 Biggs Darklighter     84   168         28224
#> 10 Obi-Wan Kenobi        77   154         23716
#> # ℹ 77 more rows

mtcars %>%
  group_by(cyl) %>%
  summarise(disp = mean(disp), sd = sd(disp))
#> # A tibble: 3 × 3
#>     cyl  disp    sd
#>   <dbl> <dbl> <dbl>
#> 1     4  105.    NA
#> 2     6  183.    NA
#> 3     8  353.    NA

qs::qsave(dplyr:::globals$archive, "archive.qs")
#> Warning in qs::qsave(dplyr:::globals$archive, "archive.qs"): 'package:dplyr'
#> may not be available when loading

#> Warning in qs::qsave(dplyr:::globals$archive, "archive.qs"): 'package:dplyr'
#> may not be available when loading

.rs.restartR()
archive <- qs::qread("archive.qs")

eval(archive$call[[1]], archive$env[[1]])
#> # A tibble: 87 × 4
#>    name                mass mass2 mass2_squared
#>    <chr>              <dbl> <dbl>         <dbl>
#>  1 Luke Skywalker        77   154         23716
#>  2 C-3PO                 75   150         22500
#>  3 R2-D2                 32    64          4096
#>  4 Darth Vader          136   272         73984
#>  5 Leia Organa           49    98          9604
#>  6 Owen Lars            120   240         57600
#>  7 Beru Whitesun lars    75   150         22500
#>  8 R5-D4                 32    64          4096
#>  9 Biggs Darklighter     84   168         28224
#> 10 Obi-Wan Kenobi        77   154         23716
#> # ℹ 77 more rows

eval(archive$call[[2]], archive$env[[2]])
#> # A tibble: 3 × 3
#>     cyl  disp    sd
#>   <dbl> <dbl> <dbl>
#> 1     4  105.    NA
#>.2     6  183.    NA
#> 3     8  353.    NA
```