### PR TITLE
iteration3

### DIFF
--- a/R/collector.R
+++ b/R/collector.R
@@ -1,0 +1,41 @@
+# initiate global tibble to store the results
+globals <- new.env()
+globals$archive <- tibble(
+  call = list(),
+  env = list()
+)
+
+# note: env_clone doesn't do deep copy, i.e we're not cloning environments that
+# are bound in `e`, or nested in lists, or found in attributes, or as function enclosures
+env_clone_lazy <- function(env) {
+  # we stop the recursion when we find a special env, defined by having a name
+  if (!is.null(attr(env, "name")) || identical(env, emptyenv())) return(env)
+  parent_clone <- env_clone_lazy(env_parent(env))
+  clone <- rlang::env_clone(env, parent = parent_clone)
+  for (nm in names(clone)) {
+    #FIXME: assumes env contains no active or lazy bindings, this could be fixed
+    env_bind_lazy(clone, !!nm := !!env[[nm]])
+  }
+  clone
+}
+
+# drop lazy bindings, since these were not used
+env_cleanup <- function(env) {
+  if (!is.null(attr(env, "name")) || identical(env, emptyenv())) return(env)
+  env_cleanup(env_parent(env))
+  lazy_lgl <- env_binding_are_lazy(env)
+  rm(list = names(lazy_lgl)[lazy_lgl], envir = env)
+}
+
+archive <- function(
+    call,
+    env
+) {
+  globals$archive  <- rbind(
+    globals$archive,
+    tibble(
+      call = list(call),
+      env = list(env)
+    )
+  )
+}

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -153,7 +153,19 @@
 #' mutate(starwars, prod = .data[[vars[[1]]]] * .data[[vars[[2]]]])
 #' # Learn more in ?dplyr_data_masking
 mutate <- function(.data, ...) {
-  UseMethod("mutate")
+  ..new_caller_env <- env_clone_lazy(parent.frame())
+  ..call = sys.call()
+  archive(
+    call = ..call,
+    env = ..new_caller_env
+  )
+  on.exit({
+    env_cleanup(..new_caller_env)
+  })
+  ..call[[1]] <- function(.data, ...) {
+    UseMethod("mutate")
+  }
+  eval(..call, ..new_caller_env)
 }
 
 #' @rdname mutate

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -117,7 +117,19 @@
 #' summarise(starwars, avg = mean(.data[[var]], na.rm = TRUE))
 #' # Learn more in ?dplyr_data_masking
 summarise <- function(.data, ..., .groups = NULL) {
-  UseMethod("summarise")
+  ..new_caller_env <- env_clone_lazy(parent.frame())
+  ..call = sys.call()
+  archive(
+    call = ..call,
+    env = ..new_caller_env
+  )
+  on.exit({
+    env_cleanup(..new_caller_env)
+  })
+  ..call[[1]] <- function(.data, ...) {
+    UseMethod("summarise")
+  }
+  eval(..call, ..new_caller_env)
 }
 #' @rdname summarise
 #' @export


### PR DESCRIPTION
I prefer https://github.com/cynkra/dplyr/pull/2 that generalises this, but this is the simpler version you asked for @krlmlr . The output is the same. I didn't publish my iteration 2 using quosures because it's more complex and harder to generalise, I can if you want though.

semi-manual reprex:

```
library(dplyr, w = F)

mutate
#> function(.data, ...) {
#>   ..new_caller_env <- env_clone_lazy(parent.frame())
#>   ..call = sys.call()
#>   archive(
#>     call = ..call,
#>     env = ..new_caller_env
#>   )
#>   on.exit({
#>     env_cleanup(..new_caller_env)
#>   })
#>   ..call[[1]] <- function(.data, ...) {
#>     UseMethod("mutate")
#>   }
#>   eval(..call, ..new_caller_env)
#> }
#> <bytecode: 0x12c036f98>
#> <environment: namespace:dplyr>

starwars %>%
  select(name, mass) %>%
  mutate(
    mass2 = mass * 2,
    mass2_squared = mass2 * mass2
  )
#> # A tibble: 87 × 4
#>    name                mass mass2 mass2_squared
#>    <chr>              <dbl> <dbl>         <dbl>
#>  1 Luke Skywalker        77   154         23716
#>  2 C-3PO                 75   150         22500
#>  3 R2-D2                 32    64          4096
#>  4 Darth Vader          136   272         73984
#>  5 Leia Organa           49    98          9604
#>  6 Owen Lars            120   240         57600
#>  7 Beru Whitesun lars    75   150         22500
#>  8 R5-D4                 32    64          4096
#>  9 Biggs Darklighter     84   168         28224
#> 10 Obi-Wan Kenobi        77   154         23716
#> # ℹ 77 more rows

mtcars %>%
  group_by(cyl) %>%
  summarise(disp = mean(disp), sd = sd(disp))
#> # A tibble: 3 × 3
#>     cyl  disp    sd
#>   <dbl> <dbl> <dbl>
#> 1     4  105.    NA
#> 2     6  183.    NA
#> 3     8  353.    NA

qs::qsave(dplyr:::globals$archive, "archive.qs")
#> Warning in qs::qsave(dplyr:::globals$archive, "archive.qs"): 'package:dplyr'
#> may not be available when loading

#> Warning in qs::qsave(dplyr:::globals$archive, "archive.qs"): 'package:dplyr'
#> may not be available when loading

.rs.restartR()
archive <- qs::qread("archive.qs")

eval(archive$call[[1]], archive$env[[1]])
#> # A tibble: 87 × 4
#>    name                mass mass2 mass2_squared
#>    <chr>              <dbl> <dbl>         <dbl>
#>  1 Luke Skywalker        77   154         23716
#>  2 C-3PO                 75   150         22500
#>  3 R2-D2                 32    64          4096
#>  4 Darth Vader          136   272         73984
#>  5 Leia Organa           49    98          9604
#>  6 Owen Lars            120   240         57600
#>  7 Beru Whitesun lars    75   150         22500
#>  8 R5-D4                 32    64          4096
#>  9 Biggs Darklighter     84   168         28224
#> 10 Obi-Wan Kenobi        77   154         23716
#> # ℹ 77 more rows

eval(archive$call[[2]], archive$env[[2]])
#> # A tibble: 3 × 3
#>     cyl  disp    sd
#>   <dbl> <dbl> <dbl>
#> 1     4  105.    NA
#>.2     6  183.    NA
#> 3     8  353.    NA
```