### PR TITLE
Use package 'collector'

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,4 +1,5 @@
 .onLoad <- function(libname, pkgname) {
+  collector::set_collector()
   op <- options()
   op.dplyr <- list(
     dplyr.show_progress = TRUE


### PR DESCRIPTION
cc @krlmlr 

This PR is a single line, to advertise the latest version described here: https://github.com/cynkra/collector/pull/1

```
library(dplyr, w = F)

starwars %>%
  select(name, mass) %>%
  mutate(
    mass2 = mass * 2,
    mass2_squared = mass2 * mass2
  )

mtcars %>%
  group_by(cyl) %>%
  summarise(disp = mean(disp), sd = sd(disp))

.rs.restartR()

reloaded <- qs::qread("collector/1-select.qs")
with(reloaded, eval(call, env))

reloaded <- qs::qread("collector/2-mutate.qs")
with(reloaded, eval(call, env))

reloaded <- qs::qread("collector/3-group_by.qs")
with(reloaded, eval(call, env))

reloaded <- qs::qread("collector/4-summarise.qs")
with(reloaded, eval(call, env))
```

It's cool to see that we need 41kB for the select call (big data frame) but only 6.2 kB for the mutate call (only 2 cols for the df)